### PR TITLE
Added support for auxiliary environment/scripts

### DIFF
--- a/src/aux
+++ b/src/aux
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Environments/scripts that can only be defined/started after the
+# versioned environments have been resolved. This file gets sourced
+# automatically before the versioned scripts initialization.
+
+# uver versions directory
+if [ -z "$UVER_VERSIONS_DIR" ]; then
+  export UVER_VERSIONS_DIR="$UVER_ROOT/$UVER_VERSION/versions"
+fi
+
+# ulauncher config directory
+if [ -z "$ULAUNCHER_CONFIG_DIR" ]; then
+  export ULAUNCHER_CONFIG_DIR="$ULAUNCHER_ROOT/$ULAUNCHER_VERSION/config"
+fi

--- a/src/init
+++ b/src/init
@@ -22,6 +22,8 @@
 if [ -z "$UPIPE_ROOT" ]; then
   echo "UPIPE_ROOT IS NOT SET, ARE YOU UNDER UPIPE ENV ?" >&2
 else
+  # current dir
+  dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
   # by default the version of versioned depedencies is driven by their
   # respective version environment. However when ubash is set to either "stable" or
@@ -62,6 +64,20 @@ else
 
     # exporting the final version of the versioned variable
     export "$versionedVersionName"=$versionedVersionValue
+  done
+
+  # running auxiliary envs after the versioned envs have been resolved and
+  # before the initialization of the versioned scripts (since the scripts
+  # may use them)
+  source $dir/aux
+
+  # running versioned initialization
+  for versioned in $versionedNames
+  do
+    versionedRootName="${versioned}_ROOT"
+    versionedRootValue="${!versionedRootName}"
+    versionedVersionName="${versioned}_VERSION"
+    versionedVersionValue="${!versionedVersionName}"
 
     # initializing versioned
     versionedLocation="$versionedRootValue/$versionedVersionValue"


### PR DESCRIPTION
Letting ubash to set the location for the config directories used by ulauncher and uver (and any versioned module that has a configuration environment). Therefore, those modules should not know anything about how to resolve those variables, instead it should just assume they are set, otherwise they should show an error message. This is done by a new file called "aux" which gets sourced after resolving the environments and before the initialized of the versioned dependencies.
