### PR TITLE
Improved support for dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,34 @@ Add the lines below at the end of `$HOME/.bashrc`:
 ```bash
 # umedia
 export UPIPE_ROOT="/data/studio/upipe"
-export UPIPE_DEV_ROOT_TARGET="$HOME/.umedia/upipe"
-export UPIPE_PATH="$UPIPE_DEV_ROOT:$UPIPE_ROOT"
+export UPIPE_DEV_ROOT="$HOME/.umedia/upipe"
 export UBASH_VERSION="stable"
 source $UPIPE_ROOT/ubash/$UBASH_VERSION/env
 source $UPIPE_ROOT/ubash/$UBASH_VERSION/init
 ```
 
+### Overriding Versions
+Overriding versions managed by ubash (UCORE, UFACILITY, UVER, ULAUNCHER and UEVENTS):
+```bash
+# ...
+source $UPIPE_ROOT/ubash/$UBASH_VERSION/env
+# it's done between 'env' and 'init'
+export UVER_VESION="0.1.0"
+export ULAUNCHER_VESION="0.1.0"
+source $UPIPE_ROOT/ubash/$UBASH_VERSION/init
+```
+
+Overriding versions managed by uver:
+```bash
+# ...
+source $UPIPE_ROOT/ubash/$UBASH_VERSION/init
+# it's done after 'init'
+export UVER_MAYATOOLS_VERSION="0.2.0"
+```
+
 ### Activating the dev environment
 In order to activate the dev env, so upipe can be aware about the resources
-installed under "UPIPE_DEV_ROOT_TARGET", you need to run:
+installed under "UPIPE_DEV_ROOT", you need to run:
 ```bash
 devenv
 ```
@@ -46,11 +64,10 @@ Finally, make sure your upipe configuration is intializing ubash from that locat
 ```bash
 # umedia (dev ubash)
 export UPIPE_ROOT="/data/studio/upipe"
-export UPIPE_DEV_ROOT_TARGET="$HOME/.umedia/upipe"
-export UPIPE_PATH="$UPIPE_DEV_ROOT:$UPIPE_ROOT"
+export UPIPE_DEV_ROOT="$HOME/.umedia/upipe"
 export UBASH_VERSION="alpha" # <-
-source $UPIPE_DEV_ROOT_TARGET/ubash/$UBASH_VERSION/env # <-
-source $UPIPE_DEV_ROOT_TARGET/ubash/$UBASH_VERSION/init # <-
+source $UPIPE_DEV_ROOT/ubash/$UBASH_VERSION/env # <-
+source $UPIPE_DEV_ROOT/ubash/$UBASH_VERSION/init # <-
 ```
 
 ### Building ubash for the first time

--- a/src/env
+++ b/src/env
@@ -2,11 +2,14 @@
 
 # prepares for the initialization of umedia environment by setting
 # the main environments that are required to get the user up running under upipe domain.
-# This file is expected to be called by the ~/.bashrc
+# This file is expected to be sourced by the ~/.bashrc
 
-# TODO: ideally it should be defined as part of the OS image deployed to the
-# users
-export UFACILITY_NAME="van"
+# default UPIPE_PATH is based UPIPE_ROOT
+# (UPIPE_DEV_ROOT is automatically prepended when running through devenv)
+export UPIPE_PATH="$UPIPE_ROOT"
+
+# ufacility (versioned)
+export UFACILITY_NAME="van" # TODO: this should be defined as part of the OS image
 export UFACILITY_VERSION=""
 
 # uver (versioned)

--- a/src/init
+++ b/src/init
@@ -18,24 +18,26 @@
 # letting users to be able to override locally any environment value that was previously
 # set during ./env execution.
 
-# auto-assigning UPIPE_PATH based on UPIPE_ROOT (when necessary)
-if [ -z "$UPIPE_PATH" ]; then
-  export UPIPE_PATH="$UPIPE_ROOT"
-fi
-
 # checking if it's being triggered under upipe domain
 if [ -z "$UPIPE_ROOT" ]; then
   echo "UPIPE_ROOT IS NOT DEFINED, ARE YOU UNDER UPIPE ENV ?" >&2
 elif [ -z "$UPIPE_PATH" ]; then
-  echo "UPIPE_PATH IS NOT DEFINED, ARE YOU UNDER UPIPE ENV ?" >&2
+  echo "UPIPE_PATH IS NOT DEFINED, DID YOU SOURCE 'ubash/env' file ?" >&2
 else
   # current dir
   dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-  # development enviromnent support
-  alias devenv='bash --init-file <(echo "export UPIPE_DEV_ROOT=$UPIPE_DEV_ROOT_TARGET && source $HOME/.bashrc")'
-  if ! [[ -z "$UPIPE_DEV_ROOT" ]]; then
-    PS1="[DEV]\t-\u@\h:\w\$ "
+  # development enviromnent support:
+  # The intial value for UPIPE_PATH is defined inside 'env' file, however we want
+  # to let the user to be able to modify this variable. Therefore, when entering in
+  # devenv we just use whatever is the current value for that variable and
+  # prepend the location for the UPIPE_DEV_ROOT. This is done after the
+  # bashrc initialization, so keeping any tweaks that may have been done by the user.
+  alias devenv='bash --init-file <(echo "export ISDEVENV=1 && source $HOME/.bashrc")'
+  if [[ "$ISDEVENV" == "1" ]]; then
+    export UPIPE_PATH="$UPIPE_DEV_ROOT:$UPIPE_PATH"
+    # adding as prefix a hint about the dev env
+    export PS1="[DEV]$PS1"
   fi
 
   # adding ubash bin path to the environment


### PR DESCRIPTION
- Added devenv as part of ubash initialization (#18)
- UPIPE_PATH is now defined under env rather than user's bashrc (#18)